### PR TITLE
Adds pure content

### DIFF
--- a/src/Setup/Styles.php
+++ b/src/Setup/Styles.php
@@ -55,6 +55,8 @@ class Styles implements EnqueueInterface
             wp_enqueue_style( 'bootstrap-grid' );
         }
 
+        // TODO add bootstrap 5.
+
         // bootstrap.
         if ( true === get_theme_mod( 'enable_bootstrap', true ) ) {
             wp_enqueue_style( 'bootstrap' );

--- a/src/Template.php
+++ b/src/Template.php
@@ -9,6 +9,7 @@ use Brisko\View\FullWidthPage;
 use Brisko\View\HomePage;
 use Brisko\View\IndexPage;
 use Brisko\View\Page;
+use Brisko\View\Content;
 use Brisko\View\Page404;
 use Brisko\View\Search;
 use Brisko\View\Sidebar;
@@ -50,6 +51,16 @@ class Template
 	public static function footer( $name = null, $args = array() )
 	{
 		get_footer( $name, $args );
+	}
+
+	/**
+	 * Displays the post content.
+	 *
+	 * @return void
+	 */
+	public static function content()
+	{
+		Content::get()->view();
 	}
 
     /**

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -34,13 +34,7 @@ class Theme
      */
     private function __construct()
     {
-        Activate::init();
-        Assets::init();
-        Body::init();
-        Head::init();
-        Jetpack::init();
-        Customizer::init();
-        // Compat::init();  @codingStandardsIgnoreLine
+		// empty.
     }
 
     /**
@@ -50,7 +44,13 @@ class Theme
      */
     public static function setup()
     {
-        return new self();
+		Activate::init();
+		Assets::init();
+		Body::init();
+		Head::init();
+		Jetpack::init();
+		Customizer::init();
+		// Compat::init();  @codingStandardsIgnoreLine
     }
 
     /**
@@ -127,6 +127,16 @@ class Theme
     public static function template()
     {
         return Template::get();
+    }
+
+	/**
+     * Template.
+     *
+     * @return Template
+     */
+    public static function content()
+    {
+        return static::template()->content();
     }
 
     /**

--- a/src/View/Content.php
+++ b/src/View/Content.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Brisko\View;
+
+use Brisko\Traits\Instance;
+
+class Content
+{
+    use Instance;
+
+	/**
+	 * Display content only.
+	 *
+	 * pure content will bypass `the_content` and use `get_the_content`
+	 * works better for pure content management and will not break html.
+	 *
+	 * note: filters on `the_content` will not work.
+	 *
+	 */
+    public function view()
+    {
+		if ( get_theme_mod( 'enable_pure_content', false ) ) {
+            echo wp_kses_post( $this->the_content() );
+        } else {
+            the_content();
+        }
+    }
+
+	/**
+     * Display content.
+     */
+    protected function the_content()
+    {
+		return get_the_content( null, false );
+    }
+
+}

--- a/template-parts/content-full-width.php
+++ b/template-parts/content-full-width.php
@@ -8,13 +8,20 @@
 	<?php Brisko\Theme::post_thumbnail(); ?>
 	<div class="full-width-content">
 		<?php
-        the_content();
-wp_link_pages(
-    [
-        'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'brisko' ),
-        'after'  => '</div>',
-    ]
-);
-?>
+		/**
+		 * pure content will bypass `the_content` and use `get_the_content`
+		 * works better for pure content management and will not break html.
+		 *
+		 * note: filters on `the_content` will not work.
+		 *
+		 */
+		Brisko\Theme::content();
+			wp_link_pages(
+			    [
+			        'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'brisko' ),
+			        'after'  => '</div>',
+			    ]
+			);
+		?>
 	</div><!-- .entry-content -->
 </article><!-- #post-<?php the_ID(); ?> -->

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -14,14 +14,21 @@
 	<?php Brisko\Theme::post_thumbnail(); ?>
 	<div class="entry-content">
 		<?php
-        the_content();
-wp_link_pages(
-    [
-        'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'brisko' ),
-        'after'  => '</div>',
-    ]
-);
-?>
+		/**
+		 * pure content will bypass `the_content` and use `get_the_content`
+		 * works better for pure content management and will not break html.
+		 *
+		 * note: filters on `the_content` will not work.
+		 *
+		 */
+		Brisko\Theme::content();
+			wp_link_pages(
+			    [
+			        'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'brisko' ),
+			        'after'  => '</div>',
+			    ]
+			);
+		?>
 	</div><!-- .entry-content -->
 	<?php if ( get_edit_post_link() ) { ?>
 		<footer class="entry-footer">


### PR DESCRIPTION
Fix: #124

The Pure Content Fix
Pure content will bypass `the_content` and use `get_the_content`, works better when using HTML, and fixes bootstrap style issues. Note: this will bypass filters that apply to `the_content`.

https://developer.wordpress.org/reference/functions/the_content/
https://developer.wordpress.org/reference/functions/get_the_content/

This was implemented only for pages, other post types will still work as expected